### PR TITLE
Set axio timeout to infinity

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -287,7 +287,7 @@ export default {
     uploadFile (file, component) {
       const request = axios.create({
         baseURL: 'https://gallery.kvnmm.com/',
-        timeout: 5000
+        timeout: 0
       })
 
       let formdata = new FormData()


### PR DESCRIPTION
  // `timeout` specifies the number of milliseconds before the request times out.
  // If the request takes longer than `timeout`, the request will be aborted.
  timeout: 1000, // default is `0` (no timeout)

有 timeout 的話發出去的 request 超過 timeout 後 axio 就 abort 不管回來的 response，會造成上傳照片永遠卡在轉圈圈，所以我把 timeout 關掉。

cc @g25259 @nizi1127 