### PR TITLE
Keep scrollbar when upload-modal is launched

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -204,6 +204,10 @@
   .upload-preview-pending{
     opacity: 0.5;
   }
+
+  .modal-open {
+    overflow: inherit !important
+  }
 </style>
 
 <script>


### PR DESCRIPTION
Override modal-open class to keep scrollbar when upload-modal is launched.

cc @g25259 