### PR TITLE
Lock bootstrap-vue version to 2.0.0-rc.10 to fix inputbox for iphone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3008,15 +3008,15 @@
       "integrity": "sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w=="
     },
     "bootstrap-vue": {
-      "version": "2.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.0-rc.11.tgz",
-      "integrity": "sha512-LxR+oL8yKr1DVoWUWTX+XhiT0xaTMH6142u2VSFDm4tewTH8HIrzN2YIl7HLZrw2DIuE9bRMIdWJqqn3aQe7Hw==",
+      "version": "2.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.0-rc.10.tgz",
+      "integrity": "sha512-i2IMwZzV16ySKqXDPowt+aIM9sBpji/gheRI/Y97tndsmGK2cD/drogSqXHPxoe/W+KdKgXCrJJN4nxpNI2xDA==",
       "requires": {
         "bootstrap": "4.1.3",
         "lodash.get": "4.4.2",
         "lodash.startcase": "4.4.0",
         "opencollective": "1.0.3",
-        "popper.js": "1.14.4",
+        "popper.js": "1.14.5",
         "vue-functional-data-merge": "2.0.7"
       }
     },
@@ -9861,7 +9861,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
           "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
         },
         "ansi-regex": {
@@ -10265,9 +10265,9 @@
       "dev": true
     },
     "popper.js": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.4.tgz",
-      "integrity": "sha1-juwdj/AqWjoVLdQ0FKFce3n9abY="
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.5.tgz",
+      "integrity": "sha512-fs4Sd8bZLgEzrk8aS7Em1qh+wcawtE87kRUJQhK6+LndyV1HerX7+LURzAylVaTyWIn5NTB/lyjnWqw/AZ6Yrw=="
     },
     "portfinder": {
       "version": "1.0.17",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "apollo-boost": "^0.1.18",
     "axios": "^0.18.0",
     "blueimp-gallery": "^2.33.0",
-    "bootstrap-vue": "^2.0.0-rc.11",
+    "bootstrap-vue": "2.0.0-rc.10",
     "date-diff": "^0.2.1",
     "graphql": "^14.0.2",
     "mockjs": "^1.0.1-beta3",


### PR DESCRIPTION
Downgrade bootstrap-vue to 2.0.0-rc.10 to fix inputbox for iphone as https://github.com/bootstrap-vue/bootstrap-vue/issues/1852#issuecomment-395430504 mentioned.